### PR TITLE
Static B benchmark

### DIFF
--- a/src/Workflows/StaticB/README.md
+++ b/src/Workflows/StaticB/README.md
@@ -1,0 +1,64 @@
+# Static B training workflow
+
+The static B training workflow is based on two directories:
+- `bump_1.0` contains all the bash scripts to compute and test the static B, version 1.0. Their usage is detailed hereafter.
+- `env_script` contains two scripts to load modules for GNU-OpenMPI and Intel-IMPI on Orion. They should be updated on other machines.
+
+## BUMP 1.0
+
+### Bash scripts
+In `bump_1.0`, the driving bash script is `main.sh`. The upper section of this script should be updated to provide:
+- Directories: for data, FV3-JEDI source and binaries, and experiments files.
+- Environment script path: examples are provided in `env_script`.
+- Parameters: variables, number of ensemble members, list of dates for the training, background and observation dates.
+- What should be run: replace `false` with `true` to run a specific step.
+
+Other bash scripts are called by `main.sh` to:
+- create appropriate directories,
+- generate `yaml` files,
+- generate `sbatch` files to run jobs on Orion (should be updated on other machines and with other accounts).
+
+### Tasks goal and dependencies
+Tasks dependencies are given between brackets. Except for the first two tasks (`create directories` and `get data`), all dependencies are implemented in the bash scripts.
+```
+├── create directories: create all need directories, should be run only once
+├── get data [create directories]: download data from S3
+├── daily runs: BUMP pre-computations for each cycle
+│   ├── daily vbal [get data]: vertical balance pre-computations for each cycle
+│   ├── daily unbal [daily vbal]: unbalance ensemble members for each cycle
+│   └── daily var-mom [daily unbal]: variance and moments pre-computations for each cycle
+├── final runs: BUMP final tasks based on pre-computations
+│   ├── final vbal [daily vbal]: final vertical balance computation
+│   ├── final var [daily var-mom]: final variance computation
+│   ├── final cor [daily var-mom]: final correlation length-scales computation
+│   ├── final nicas [final cor]: NICAS operator computation
+│   └── final psichitouv [get data]: psi/chi to u/v operator computation
+├── merge runs: merge final runs results computed independently for each variable
+│   ├── merge var-cor [final var, final cor]: merge variance and correlation length-scales files
+│   └── merge nicas [final nicas]: merge NICAS files
+├── spilt runs: split global BUMP files to use local files with a 7x7 layout
+│   ├── split vbal [final vbal]: split global vertical balance file
+│   ├── split nicas [merge nicas]: split global NICAS files
+│   └── split psichitouv [final psichitouv]: split global psi/chi to u/v file
+├── regrid runs: regrid files to use the static B at another resolution
+│   ├── regrid background [get data]: regrid background
+│   ├── regrid first member [get data]: regrid first ensemble member
+│   ├── regrid psichitouv [final psichitouv, regrid first member]: regrid psi/chi to u/v file
+│   ├── regrid var-cor [merge var-cor]: regrid variance and correlation length-scales fields
+│   ├── regrid nicas [final nicas, regrid first member]: regrid NICAS files
+│   └── regrid merge nicas [regrid nicas]: merge regridded NICAS files
+├── dirac runs: Dirac test for each component
+│   ├── dirac cor local [merge nicas]: Dirac test for local NICAS correlation operator
+│   ├── dirac cor global [merge nicas]: Dirac test for global NICAS correlation operator
+│   ├── dirac cov local [merge nicas, merge var-cor]: Dirac test for local NICAS correlation operator + standard-deviation
+│   ├── dirac cov global [merge nicas, merge var-cor]: Dirac test for global NICAS correlation operator + standard-deviation
+│   ├── dirac cov multi local [merge nicas, merge var-cor, final vbal]: Dirac test for local NICAS correlation operator + standard-deviation + vertical balance
+│   ├── dirac cov multi global [merge nicas, merge var-cor, final vbal]: Dirac test for global NICAS correlation operator + standard-deviation + vertical balance
+│   ├── dirac full c2a local [merge nicas, merge var-cor, final vbal]: Dirac test of the full local static B, using the FV3-JEDI-based psi/chi to u/v transform
+│   ├── dirac full psichitouv local [merge nicas, merge var-cor, final vbal, final psichitouv]: Dirac test of the full local static B, using the BUMP-based psi/chi to u/v transform
+│   ├── dirac full global [merge nicas, merge var-cor, final vbal]: Dirac test of the full static B, using the full global static B, using the BUMP-based psi/chi to u/v transform
+│   ├── dirac full c192 local [regrid merge nicas, regrid var-cor, final vbal, regrid psichitouv, regrid background]: Dirac test of the full local static B at resolution C192, using the BUMP-based psi/chi to u/v transform
+│   └── dirac full 7x7 local [split nicas, merge var-cor, split vbal, split psichitouv]: Dirac test of the full local static B with a 7x7 layout, using the BUMP-based psi/chi to u/v transform
+└── variational runs: variational runs using the static B
+    └── variational 3dvar [merge nica, merge varcor, final vbal, final psichitouv]: 3DVar using the static B
+```

--- a/src/Workflows/StaticB/bump_1.0/dirac.sh
+++ b/src/Workflows/StaticB/bump_1.0/dirac.sh
@@ -670,7 +670,7 @@ geometry:
   - fieldset: ${fv3jedi_dir}/test/Data/fieldsets/dynamics.yaml
 initial condition:
   filetype: gfs
-  datapath: ${data_dir_c384}/${bkg_obs_dir}
+  datapath: ${data_dir_c384}/${bkg_dir}
   filename_cplr: coupler.res
   filename_core: fv_core.res.nc
   filename_trcr: fv_tracer.res.nc
@@ -740,7 +740,7 @@ output B:
   filetype: geos
   datapath: ${data_dir_c384}/${bump_dir}/geos
   filename_bkgd: dirac_full_c2a_local_${yyyymmddhh_first}-${yyyymmddhh_last}.nc4
-  date: ${yyyy_obs}-${mm_obs}-${dd_obs}T${hh_obs}:00:00Z
+  date: ${yyyy_bkg}-${mm_bkg}-${dd_bkg}T${hh_bkg}:00:00Z
 dirac:
   ndir: 6
   ixdir: [192,192,192,192,192,192]
@@ -796,7 +796,7 @@ geometry:
   - fieldset: ${fv3jedi_dir}/test/Data/fieldsets/dynamics.yaml
 initial condition:
   filetype: gfs
-  datapath: ${data_dir_c384}/${bkg_obs_dir}
+  datapath: ${data_dir_c384}/${bkg_dir}
   filename_cplr: coupler.res
   filename_core: fv_core.res.nc
   filename_trcr: fv_tracer.res.nc
@@ -869,15 +869,11 @@ background error:
       verbosity: main
       universe_rad: 2000.0e3
       load_wind_local: 1
-      wind_streamfunction: stream_function
-      wind_velocity_potential: velocity_potential
-      wind_zonal: eastward_wind
-      wind_meridional: northward_wind
 output B:
   filetype: geos
   datapath: ${data_dir_c384}/${bump_dir}/geos
   filename_bkgd: dirac_full_psichitouv_local_${yyyymmddhh_first}-${yyyymmddhh_last}.nc4
-  date: ${yyyy_obs}-${mm_obs}-${dd_obs}T${hh_obs}:00:00Z
+  date: ${yyyy_bkg}-${mm_bkg}-${dd_bkg}T${hh_bkg}:00:00Z
 dirac:
   ndir: 6
   ixdir: [192,192,192,192,192,192]
@@ -933,7 +929,7 @@ geometry:
   - fieldset: ${fv3jedi_dir}/test/Data/fieldsets/dynamics.yaml
 initial condition:
   filetype: gfs
-  datapath: ${data_dir_c384}/${bkg_obs_dir}
+  datapath: ${data_dir_c384}/${bkg_dir}
   filename_cplr: coupler.res
   filename_core: fv_core.res.nc
   filename_trcr: fv_tracer.res.nc
@@ -1006,15 +1002,11 @@ background error:
       verbosity: main
       universe_rad: 2000.0e3
       load_wind_local: 1
-      wind_streamfunction: stream_function
-      wind_velocity_potential: velocity_potential
-      wind_zonal: eastward_wind
-      wind_meridional: northward_wind
 output B:
   filetype: geos
   datapath: ${data_dir_c384}/${bump_dir}/geos
   filename_bkgd: dirac_full_global_${yyyymmddhh_first}-${yyyymmddhh_last}.nc4
-  date: ${yyyy_obs}-${mm_obs}-${dd_obs}T${hh_obs}:00:00Z
+  date: ${yyyy_bkg}-${mm_bkg}-${dd_bkg}T${hh_bkg}:00:00Z
 dirac:
   ndir: 6
   ixdir: [192,192,192,192,192,192]
@@ -1070,7 +1062,7 @@ geometry:
   - fieldset: ${fv3jedi_dir}/test/Data/fieldsets/dynamics.yaml
 initial condition:
   filetype: gfs
-  datapath: ${data_dir_c192}/${bkg_obs_dir}
+  datapath: ${data_dir_c192}/${bkg_dir}
   filename_cplr: coupler.res
   filename_core: fv_core.res.nc
   filename_trcr: fv_tracer.res.nc
@@ -1136,15 +1128,11 @@ background error:
       verbosity: main
       universe_rad: 2000.0e3
       load_wind_local: 1
-      wind_streamfunction: stream_function
-      wind_velocity_potential: velocity_potential
-      wind_zonal: eastward_wind
-      wind_meridional: northward_wind
 output B:
   filetype: geos
   datapath: ${data_dir_c192}/${bump_dir}/geos
   filename_bkgd: dirac_full_c192_local_${yyyymmddhh_first}-${yyyymmddhh_last}.nc4
-  date: ${yyyy_obs}-${mm_obs}-${dd_obs}T${hh_obs}:00:00Z
+  date: ${yyyy_bkg}-${mm_bkg}-${dd_bkg}T${hh_bkg}:00:00Z
 dirac:
   ndir: 6
   ixdir: [64,64,64,64,64,64]
@@ -1200,7 +1188,7 @@ geometry:
   - fieldset: ${fv3jedi_dir}/test/Data/fieldsets/dynamics.yaml
 initial condition:
   filetype: gfs
-  datapath: ${data_dir_c384}/${bkg_obs_dir}
+  datapath: ${data_dir_c384}/${bkg_dir}
   filename_cplr: coupler.res
   filename_core: fv_core.res.nc
   filename_trcr: fv_tracer.res.nc
@@ -1273,15 +1261,11 @@ background error:
       verbosity: main
       universe_rad: 2000.0e3
       load_wind_local: 1
-      wind_streamfunction: stream_function
-      wind_velocity_potential: velocity_potential
-      wind_zonal: eastward_wind
-      wind_meridional: northward_wind
 output B:
   filetype: geos
   datapath: ${data_dir_c384}/${bump_dir}/geos
   filename_bkgd: dirac_full_7x7_local_${yyyymmddhh_first}-${yyyymmddhh_last}.nc4
-  date: ${yyyy_obs}-${mm_obs}-${dd_obs}T${hh_obs}:00:00Z
+  date: ${yyyy_bkg}-${mm_bkg}-${dd_bkg}T${hh_bkg}:00:00Z
 dirac:
   ndir: 6
   ixdir: [192,192,192,192,192,192]

--- a/src/Workflows/StaticB/bump_1.0/main.sh
+++ b/src/Workflows/StaticB/bump_1.0/main.sh
@@ -33,11 +33,9 @@ export bin_dir="${HOME}/build/gnu-openmpi/bundle_RelWithDebInfo/bin"
 # Experiments directory
 export xp_dir="${HOME}/xp"
 
-# BUMP subdirectory name
-export bump_dir="bump_1.0"
-
 ####################################################################
-# Environment script (gnu-openmpi or intel-impi) ###################
+# Environment script path ##########################################
+# Provided: gnu-openmpi or intel-impi on Orion #####################
 ####################################################################
 
 export env_script=${xp_dir}/env_script/gnu-openmpi_env.sh
@@ -46,13 +44,14 @@ export env_script=${xp_dir}/env_script/gnu-openmpi_env.sh
 ####################################################################
 # Parameters #######################################################
 ####################################################################
+
 # Variables
 export vars="psi chi t ps sphum liq_wat o3mr"
 
 # Number of ensemble members
 export nmem=80
 
-# List of cycles for training (january or july)
+# List of dates for the training (january or july)
 export yyyymmddhh_list="2020010100 2020010200 2020010300 2020010400 2020010500 2020010600 2020010700 2020010800 2020010900 2020011000"
 #export yyyymmddhh_list="2020070100 2020070200 2020070300 2020070400 2020070500 2020070600 2020070700 2020070800 2020070900 2020071000"
 
@@ -67,7 +66,7 @@ export yyyymmddhh_obs="2020121421"
 ####################################################################
 
 # Create directories
-export create_directories=true
+export create_directories=false
 
 # Get data
 export get_data=false
@@ -94,13 +93,13 @@ export nsplit=7
 export run_split_vbal=false
 export run_split_nicas=false
 
-# Regridding runs (at C192)
-export run_regridding_background=true
-export run_regridding_first_member=true
-export run_regridding_psichitouv=true
-export run_regridding_varcor=true
-export run_regridding_nicas=true
-export run_regridding_merge_nicas=true
+# Regrid runs (at C192)
+export run_regrid_background=false
+export run_regrid_first_member=false
+export run_regrid_psichitouv=false
+export run_regrid_varcor=false
+export run_regrid_nicas=false
+export run_regrid_merge_nicas=false
 
 # Dirac runs
 export run_dirac_cor_local=false
@@ -111,7 +110,7 @@ export run_dirac_cov_multi_local=false
 export run_dirac_cov_multi_global=false
 export run_dirac_full_c2a_local=false
 export run_dirac_full_psichitouv_local=false
-export run_dirac_full_c192_local=true
+export run_dirac_full_c192_local=false
 export run_dirac_full_7x7_local=false
 export run_dirac_full_global=false
 
@@ -160,6 +159,7 @@ export data_dir_c384=${data_dir}/c384
 export data_dir_c192=${data_dir}/c192
 export first_member_dir="${yyyymmddhh_last}/mem001"
 export bkg_dir="bkg_${yyyymmddhh_bkg}"
+export bump_dir="bump_1.0"
 export sbatch_dir="${xp_dir}/${bump_dir}/sbatch"
 export work_dir="${xp_dir}/${bump_dir}/work"
 export yaml_dir="${xp_dir}/${bump_dir}/yaml"
@@ -281,9 +281,9 @@ if test "${run_split_psichitouv}" = "true" || "${run_split_vbal}" = "true" || "$
    ./split.sh
 fi
 
-if test "${run_regridding_background}" = "true" || "${run_regridding_first_member}" = "true" || "${run_regridding_psichitouv}" = "true" || "${run_regridding_varcor}" = "true" || "${run_regridding_nicas}" = "true" || "${run_regridding_merge_nicas}" = "true" ; then
-   # Regridding runs
-   ./regridding.sh
+if test "${run_regrid_background}" = "true" || "${run_regrid_first_member}" = "true" || "${run_regrid_psichitouv}" = "true" || "${run_regrid_varcor}" = "true" || "${run_regrid_nicas}" = "true" || "${run_regrid_merge_nicas}" = "true" ; then
+   # Regrid runs
+   ./regrid.sh
 fi
 
 if test "${run_dirac_cor_local}" = "true" || "${run_dirac_cor_global}" = "true" || "${run_dirac_cov_local}" = "true" || "${run_dirac_cov_global}" = "true" || test "${run_dirac_cov_multi_local}" = "true" || "${run_dirac_cov_multi_global}" = "true" || "${run_dirac_full_c2a_local}" = "true" || "${run_dirac_full_psichitouv_local}" = "true" || test "${run_dirac_full_c192_local}" = "true" || "${run_dirac_full_7x7_local}" = "true" || "${run_dirac_full_global}" = "true"; then
@@ -415,46 +415,46 @@ if test "${run_split_psichitouv}" = "true"; then
    split_psichitouv_pid=:${pid}
 fi
 
-# Regridding runs
-# ---------------
+# Regrid runs
+# -----------
 
 # Run background
-if test "${run_regridding_background}" = "true"; then
-   run_sbatch regridding_background.sh
-   regridding_background_pid=:${pid}
+if test "${run_regrid_background}" = "true"; then
+   run_sbatch regrid_background.sh
+   regrid_background_pid=:${pid}
 fi
 
 # Run first member
-if test "${run_regridding_first_member}" = "true"; then
-   run_sbatch regridding_first_member_${yyyymmddhh_last}.sh
-   regridding_first_member_pid=:${pid}
+if test "${run_regrid_first_member}" = "true"; then
+   run_sbatch regrid_first_member_${yyyymmddhh_last}.sh
+   regrid_first_member_pid=:${pid}
 fi
 
 # Run psichitouv
-if test "${run_regridding_psichitouv}" = "true"; then
-   run_sbatch regridding_psichitouv_${yyyymmddhh_first}-${yyyymmddhh_last}.sh ${final_psichitouv_pid}${regridding_first_member_pid}
-   regridding_psichitouv_pid=:${pid}
+if test "${run_regrid_psichitouv}" = "true"; then
+   run_sbatch regrid_psichitouv_${yyyymmddhh_first}-${yyyymmddhh_last}.sh ${final_psichitouv_pid}${regrid_first_member_pid}
+   regrid_psichitouv_pid=:${pid}
 fi
 
 # Run var-cor
-if test "${run_regridding_varcor}" = "true"; then
-   run_sbatch regridding_var-cor_${yyyymmddhh_first}-${yyyymmddhh_last}.sh ${merge_varcor_pid}
-   regridding_varcor_pid=:${pid}
+if test "${run_regrid_varcor}" = "true"; then
+   run_sbatch regrid_var-cor_${yyyymmddhh_first}-${yyyymmddhh_last}.sh ${merge_varcor_pid}
+   regrid_varcor_pid=:${pid}
 fi
 
 # Run nicas
-if test "${run_regridding_nicas}" = "true"; then
-   regridding_nicas_pids=""
+if test "${run_regrid_nicas}" = "true"; then
+   regrid_nicas_pids=""
    for var in ${vars}; do
-      run_sbatch regridding_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_${var}.sh ${final_nicas_pids}${regridding_first_member_pid}
-      regridding_nicas_pids=${regridding_nicas_pids}:${pid}
+      run_sbatch regrid_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_${var}.sh ${final_nicas_pids}${regrid_first_member_pid}
+      regrid_nicas_pids=${regrid_nicas_pids}:${pid}
    done
 fi
 
 # Run merge nicas
-if test "${run_regridding_merge_nicas}" = "true"; then
-   run_sbatch regridding_merge_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}.sh ${regridding_nicas_pids}
-   regridding_merge_nicas_pid=:${pid}
+if test "${run_regrid_merge_nicas}" = "true"; then
+   run_sbatch regrid_merge_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}.sh ${regrid_nicas_pids}
+   regrid_merge_nicas_pid=:${pid}
 fi
 
 # Dirac runs
@@ -516,7 +516,7 @@ fi
 
 # Run dirac_full_c192_local
 if test "${run_dirac_full_c192_local}" = "true"; then
-   run_sbatch dirac_full_c192_local_${yyyymmddhh_first}-${yyyymmddhh_last}.sh ${regridding_merge_nicas_pid}${regridding_varcor_pid}${final_vbal_pid}${regridding_psichitouv_pid}${regridding_background_pid}
+   run_sbatch dirac_full_c192_local_${yyyymmddhh_first}-${yyyymmddhh_last}.sh ${regrid_merge_nicas_pid}${regrid_varcor_pid}${final_vbal_pid}${regrid_psichitouv_pid}${regrid_background_pid}
    dirac_full_c192_local_pid=:${pid}
 fi
 

--- a/src/Workflows/StaticB/bump_1.0/main.sh
+++ b/src/Workflows/StaticB/bump_1.0/main.sh
@@ -56,7 +56,10 @@ export nmem=80
 export yyyymmddhh_list="2020010100 2020010200 2020010300 2020010400 2020010500 2020010600 2020010700 2020010800 2020010900 2020011000"
 #export yyyymmddhh_list="2020070100 2020070200 2020070300 2020070400 2020070500 2020070600 2020070700 2020070800 2020070900 2020071000"
 
-# Observation cycle
+# Background date
+export yyyymmddhh_bkg="2020121500"
+
+# Observation date
 export yyyymmddhh_obs="2020121421"
 
 ####################################################################
@@ -64,7 +67,7 @@ export yyyymmddhh_obs="2020121421"
 ####################################################################
 
 # Create directories
-export create_directories=false
+export create_directories=true
 
 # Get data
 export get_data=false
@@ -92,12 +95,12 @@ export run_split_vbal=false
 export run_split_nicas=false
 
 # Regridding runs (at C192)
-export run_regridding_background=false
-export run_regridding_first_member=false
-export run_regridding_psichitouv=false
-export run_regridding_varcor=false
-export run_regridding_nicas=false
-export run_regridding_merge_nicas=false
+export run_regridding_background=true
+export run_regridding_first_member=true
+export run_regridding_psichitouv=true
+export run_regridding_varcor=true
+export run_regridding_nicas=true
+export run_regridding_merge_nicas=true
 
 # Dirac runs
 export run_dirac_cor_local=false
@@ -108,7 +111,7 @@ export run_dirac_cov_multi_local=false
 export run_dirac_cov_multi_global=false
 export run_dirac_full_c2a_local=false
 export run_dirac_full_psichitouv_local=false
-export run_dirac_full_c192_local=false
+export run_dirac_full_c192_local=true
 export run_dirac_full_7x7_local=false
 export run_dirac_full_global=false
 
@@ -137,6 +140,10 @@ export hh_last=${yyyymmddhh_last:8:2}
 export m_last=${mm_last##0}
 export d_last=${dd_last##0}
 export h_last=${hh_last##0}
+export yyyy_bkg=${yyyymmddhh_bkg:0:4}
+export mm_bkg=${yyyymmddhh_bkg:4:2}
+export dd_bkg=${yyyymmddhh_bkg:6:2}
+export hh_bkg=${yyyymmddhh_bkg:8:2}
 export yyyy_obs=${yyyymmddhh_obs:0:4}
 export mm_obs=${yyyymmddhh_obs:4:2}
 export dd_obs=${yyyymmddhh_obs:6:2}
@@ -144,6 +151,7 @@ export hh_obs=${yyyymmddhh_obs:8:2}
 echo `date`": dates are ${yyyymmddhh_list}"
 echo `date`": first date is ${yyyymmddhh_first}"
 echo `date`": last date is ${yyyymmddhh_last}"
+echo `date`": background date is ${yyyymmddhh_bkg}"
 echo `date`": observations date is ${yyyymmddhh_obs}"
 
 # Define directories
@@ -151,8 +159,7 @@ echo `date`": define directories"
 export data_dir_c384=${data_dir}/c384
 export data_dir_c192=${data_dir}/c192
 export first_member_dir="${yyyymmddhh_last}/mem001"
-export bkg_dir="bkg_${yyyymmddhh_last}"
-export bkg_obs_dir="bkg_${yyyymmddhh_obs}"
+export bkg_dir="bkg_${yyyymmddhh_bkg}"
 export sbatch_dir="${xp_dir}/${bump_dir}/sbatch"
 export work_dir="${xp_dir}/${bump_dir}/work"
 export yaml_dir="${xp_dir}/${bump_dir}/yaml"
@@ -215,16 +222,16 @@ if test "${get_data}" = "true"; then
    done
 
    # Get background
-   echo `date`": aws s3 cp s3://fv3-jedi/StaticBTraining/C384/Background/bkg_2020121421.tar . --quiet"
-   aws s3 cp s3://fv3-jedi/StaticBTraining/C384/Background/bkg_2020121421.tar . --quiet
+   echo `date`": aws s3 cp s3://fv3-jedi/StaticBTraining/C384/Background/bkg_${yyyymmddhh_bkg}.tar . --quiet"
+   aws s3 cp s3://fv3-jedi/StaticBTraining/C384/Background/bkg_${yyyymmddhh_bkg}.tar . --quiet
 
    # Untar background
-   echo `date`": tar -xvf bkg_2020121421.tar"
-   tar -xvf bkg_2020121421.tar
+   echo `date`": tar -xvf bkg_${yyyymmddhh_bkg}.tar"
+   tar -xvf bkg_${yyyymmddhh_bkg}.tar
 
    # Remove archive
-   echo `date`": rm -f bkg_2020121421.tar"
-   rm -f bkg_2020121421.tar
+   echo `date`": rm -f bkg_${yyyymmddhh_bkg}.tar"
+   rm -f bkg_${yyyymmddhh_bkg}.tar
 
    # Go to data directory
    echo `date`": cd ${data_dir}"

--- a/src/Workflows/StaticB/bump_1.0/regrid.sh
+++ b/src/Workflows/StaticB/bump_1.0/regrid.sh
@@ -5,10 +5,10 @@
 ####################################################################
 
 # Create specific work directory
-mkdir -p ${work_dir}/regridding_background
+mkdir -p ${work_dir}/regrid_background
 
-# REGRIDDING_BACKGROUND yaml
-yaml_name="regridding_background.yaml"
+# BACKGROUND yaml
+yaml_name="regrid_background.yaml"
 cat<< EOF > ${yaml_dir}/${yaml_name}
 input geometry:
   fms initialization:
@@ -49,23 +49,23 @@ states:
     filename_trcr: fv_tracer.res.nc
 EOF
 
-# REGRIDDING_BACKGROUND sbatch
-sbatch_name="regridding_background.sh"
+# BACKGROUND sbatch
+sbatch_name="regrid_background.sh"
 cat<< EOF > ${sbatch_dir}/${sbatch_name}
 #!/bin/bash
-#SBATCH --job-name=regridding_background
+#SBATCH --job-name=regrid_background
 #SBATCH -A da-cpu
 #SBATCH -p orion
 #SBATCH -q batch
 #SBATCH --ntasks=216
 #SBATCH --cpus-per-task=1
 #SBATCH --time=00:10:00
-#SBATCH -e ${work_dir}/regridding_background/regridding_background.err
-#SBATCH -o ${work_dir}/regridding_background/regridding_background.out
+#SBATCH -e ${work_dir}/regrid_background/regrid_background.err
+#SBATCH -o ${work_dir}/regrid_background/regrid_background.out
 
 source ${env_script}
 
-cd ${work_dir}/regridding_background
+cd ${work_dir}/regrid_background
 mpirun -n 216 ${bin_dir}/fv3jedi_convertstate.x ${yaml_dir}/${yaml_name}
 
 for i in \$(seq 1 6); do
@@ -83,10 +83,10 @@ EOF
 ####################################################################
 
 # Create specific work directory
-mkdir -p ${work_dir}/regridding_first_member_${yyyymmddhh_last}
+mkdir -p ${work_dir}/regrid_first_member_${yyyymmddhh_last}
 
-# REGRIDDING_FIRST_MEMBER yaml
-yaml_name="regridding_first_member_${yyyymmddhh_last}.yaml"
+# FIRST_MEMBER yaml
+yaml_name="regrid_first_member_${yyyymmddhh_last}.yaml"
 cat<< EOF > ${yaml_dir}/${yaml_name}
 input geometry:
   fms initialization:
@@ -126,23 +126,23 @@ states:
     filename_cplr: bvars.coupler.res
 EOF
 
-# REGRIDDING_FIRST_MEMBER sbatch
-sbatch_name="regridding_first_member_${yyyymmddhh_last}.sh"
+# FIRST_MEMBER sbatch
+sbatch_name="regrid_first_member_${yyyymmddhh_last}.sh"
 cat<< EOF > ${sbatch_dir}/${sbatch_name}
 #!/bin/bash
-#SBATCH --job-name=regridding_first_member_${yyyymmddhh_last}
+#SBATCH --job-name=regrid_first_member_${yyyymmddhh_last}
 #SBATCH -A da-cpu
 #SBATCH -p orion
 #SBATCH -q batch
 #SBATCH --ntasks=216
 #SBATCH --cpus-per-task=1
 #SBATCH --time=00:10:00
-#SBATCH -e ${work_dir}/regridding_first_member_${yyyymmddhh_last}/regridding_first_member_${yyyymmddhh_last}.err
-#SBATCH -o ${work_dir}/regridding_first_member_${yyyymmddhh_last}/regridding_first_member_${yyyymmddhh_last}.out
+#SBATCH -e ${work_dir}/regrid_first_member_${yyyymmddhh_last}/regrid_first_member_${yyyymmddhh_last}.err
+#SBATCH -o ${work_dir}/regrid_first_member_${yyyymmddhh_last}/regrid_first_member_${yyyymmddhh_last}.out
 
 source ${env_script}
 
-cd ${work_dir}/regridding_first_member_${yyyymmddhh_last}
+cd ${work_dir}/regrid_first_member_${yyyymmddhh_last}
 mpirun -n 216 ${bin_dir}/fv3jedi_convertstate.x ${yaml_dir}/${yaml_name}
 
 for i in \$(seq 1 6); do
@@ -162,10 +162,10 @@ EOF
 
 # Create specific work directory
 mkdir -p ${data_dir_c192}/${bump_dir}/psichitouv_${yyyymmddhh_first}-${yyyymmddhh_last}
-mkdir -p ${work_dir}/regridding_psichitouv_${yyyymmddhh_first}-${yyyymmddhh_last}
+mkdir -p ${work_dir}/regrid_psichitouv_${yyyymmddhh_first}-${yyyymmddhh_last}
 
 # PSICHITOUV yaml
-yaml_name="regridding_psichitouv_${yyyymmddhh_first}-${yyyymmddhh_last}.yaml"
+yaml_name="regrid_psichitouv_${yyyymmddhh_first}-${yyyymmddhh_last}.yaml"
 cat<< EOF > ${yaml_dir}/${yaml_name}
 geometry:
   fms initialization:
@@ -202,23 +202,23 @@ bump:
 EOF
 
 # PSICHITOUV sbatch
-sbatch_name="regridding_psichitouv_${yyyymmddhh_first}-${yyyymmddhh_last}.sh"
+sbatch_name="regrid_psichitouv_${yyyymmddhh_first}-${yyyymmddhh_last}.sh"
 cat<< EOF > ${sbatch_dir}/${sbatch_name}
 #!/bin/bash
-#SBATCH --job-name=regridding_psichitouv_${yyyymmddhh_first}-${yyyymmddhh_last}
+#SBATCH --job-name=regrid_psichitouv_${yyyymmddhh_first}-${yyyymmddhh_last}
 #SBATCH -A da-cpu
 #SBATCH -p orion
 #SBATCH -q batch
 #SBATCH --ntasks=216
 #SBATCH --cpus-per-task=1
 #SBATCH --time=00:20:00
-#SBATCH -e ${work_dir}/regridding_psichitouv_${yyyymmddhh_first}-${yyyymmddhh_last}/regridding_psichitouv_${yyyymmddhh_first}-${yyyymmddhh_last}.err
-#SBATCH -o ${work_dir}/regridding_psichitouv_${yyyymmddhh_first}-${yyyymmddhh_last}/regridding_psichitouv_${yyyymmddhh_first}-${yyyymmddhh_last}.out
+#SBATCH -e ${work_dir}/regrid_psichitouv_${yyyymmddhh_first}-${yyyymmddhh_last}/regrid_psichitouv_${yyyymmddhh_first}-${yyyymmddhh_last}.err
+#SBATCH -o ${work_dir}/regrid_psichitouv_${yyyymmddhh_first}-${yyyymmddhh_last}/regrid_psichitouv_${yyyymmddhh_first}-${yyyymmddhh_last}.out
 
 export OMP_NUM_THREADS=2
 source ${env_script}
 
-cd ${work_dir}/regridding_psichitouv_${yyyymmddhh_first}-${yyyymmddhh_last}
+cd ${work_dir}/regrid_psichitouv_${yyyymmddhh_first}-${yyyymmddhh_last}
 mpirun -n 216 ${bin_dir}/fv3jedi_parameters.x ${yaml_dir}/${yaml_name}
 
 exit 0
@@ -229,14 +229,14 @@ EOF
 ####################################################################
 
 # Create specific work directory
-mkdir -p ${work_dir}/regridding_var-cor_${yyyymmddhh_first}-${yyyymmddhh_last}
+mkdir -p ${work_dir}/regrid_var-cor_${yyyymmddhh_first}-${yyyymmddhh_last}
 
 # Create output directory
 mkdir -p ${data_dir_c192}/${bump_dir}/var_${yyyymmddhh_first}-${yyyymmddhh_last}
 mkdir -p ${data_dir_c192}/${bump_dir}/cor_${yyyymmddhh_first}-${yyyymmddhh_last}
 
 # VAR-COR yaml
-yaml_name="regridding_var-cor_${yyyymmddhh_first}-${yyyymmddhh_last}.yaml"
+yaml_name="regrid_var-cor_${yyyymmddhh_first}-${yyyymmddhh_last}.yaml"
 cat<< EOF > ${yaml_dir}/${yaml_name}
 input geometry:
   fms initialization:
@@ -298,22 +298,22 @@ states:
 EOF
 
 # VAR-COR sbatch
-sbatch_name="regridding_var-cor_${yyyymmddhh_first}-${yyyymmddhh_last}.sh"
+sbatch_name="regrid_var-cor_${yyyymmddhh_first}-${yyyymmddhh_last}.sh"
 cat<< EOF > ${sbatch_dir}/${sbatch_name}
 #!/bin/bash
-#SBATCH --job-name=regridding_var-cor_${yyyymmddhh_first}-${yyyymmddhh_last}
+#SBATCH --job-name=regrid_var-cor_${yyyymmddhh_first}-${yyyymmddhh_last}
 #SBATCH -A da-cpu
 #SBATCH -p orion
 #SBATCH -q batch
 #SBATCH --ntasks=216
 #SBATCH --cpus-per-task=1
 #SBATCH --time=00:20:00
-#SBATCH -e ${work_dir}/regridding_var-cor_${yyyymmddhh_first}-${yyyymmddhh_last}/regridding_var-cor_${yyyymmddhh_first}-${yyyymmddhh_last}.err
-#SBATCH -o ${work_dir}/regridding_var-cor_${yyyymmddhh_first}-${yyyymmddhh_last}/regridding_var-cor_${yyyymmddhh_first}-${yyyymmddhh_last}.out
+#SBATCH -e ${work_dir}/regrid_var-cor_${yyyymmddhh_first}-${yyyymmddhh_last}/regrid_var-cor_${yyyymmddhh_first}-${yyyymmddhh_last}.err
+#SBATCH -o ${work_dir}/regrid_var-cor_${yyyymmddhh_first}-${yyyymmddhh_last}/regrid_var-cor_${yyyymmddhh_first}-${yyyymmddhh_last}.out
 
 source ${env_script}
 
-cd ${work_dir}/regridding_var-cor_${yyyymmddhh_first}-${yyyymmddhh_last}
+cd ${work_dir}/regrid_var-cor_${yyyymmddhh_first}-${yyyymmddhh_last}
 mpirun -n 216 ${bin_dir}/fv3jedi_convertstate.x ${yaml_dir}/${yaml_name}
 
 exit 0
@@ -326,14 +326,14 @@ EOF
 for var in ${vars}; do
    # Create specific BUMP and work directories
    mkdir -p ${data_dir_c192}/${bump_dir}/nicas_${yyyymmddhh_first}-${yyyymmddhh_last}
-   mkdir -p ${work_dir}/regridding_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_${var}
+   mkdir -p ${work_dir}/regrid_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_${var}
 
    # Link input files
    ln -sf ${data_dir_c384}/${bump_dir}/nicas_${yyyymmddhh_first}-${yyyymmddhh_last}/nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_${var}_nicas.nc ${data_dir_c192}/${bump_dir}/nicas_${yyyymmddhh_first}-${yyyymmddhh_last}/nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_${var}_nicas.nc
    ln -sf ${data_dir_c384}/${bump_dir}/nicas_${yyyymmddhh_first}-${yyyymmddhh_last}/nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_${var}_nicas.nc ${data_dir_c192}/${bump_dir}/nicas_${yyyymmddhh_first}-${yyyymmddhh_last}/nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_${var}_nicas.nc
 
    # NICAS yaml
-   yaml_name="regridding_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_${var}.yaml"
+   yaml_name="regrid_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_${var}.yaml"
 cat<< EOF > ${yaml_dir}/${yaml_name}
 geometry:
   fms initialization:
@@ -376,23 +376,23 @@ universe radius:
 EOF
 
    # NICAS sbatch
-   sbatch_name="regridding_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_${var}.sh"
+   sbatch_name="regrid_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_${var}.sh"
 cat<< EOF > ${sbatch_dir}/${sbatch_name}
 #!/bin/bash
-#SBATCH --job-name=regridding_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_${var}
+#SBATCH --job-name=regrid_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_${var}
 #SBATCH -A da-cpu
 #SBATCH -p orion
 #SBATCH -q batch
 #SBATCH --ntasks=216
 #SBATCH --cpus-per-task=2
 #SBATCH --time=00:20:00
-#SBATCH -e ${work_dir}/regridding_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_${var}/regridding_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_${var}.err
-#SBATCH -o ${work_dir}/regridding_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_${var}/regridding_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_${var}.out
+#SBATCH -e ${work_dir}/regrid_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_${var}/regrid_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_${var}.err
+#SBATCH -o ${work_dir}/regrid_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_${var}/regrid_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_${var}.out
 
 export OMP_NUM_THREADS=2
 source ${env_script}
 
-cd ${work_dir}/regridding_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_${var}
+cd ${work_dir}/regrid_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_${var}
 mpirun -n 216 ${bin_dir}/fv3jedi_parameters.x ${yaml_dir}/${yaml_name}
 
 exit 0
@@ -404,26 +404,26 @@ done
 ####################################################################
 
 # Create specific work directory
-mkdir -p ${work_dir}/regridding_merge_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}
+mkdir -p ${work_dir}/regrid_merge_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}
 
 # Merge local NICAS files
-sbatch_name="regridding_merge_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}.sh"
+sbatch_name="regrid_merge_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}.sh"
 cat<< EOF > ${sbatch_dir}/${sbatch_name}
 #!/bin/bash
-#SBATCH --job-name=regridding_merge_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}
+#SBATCH --job-name=regrid_merge_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}
 #SBATCH -A da-cpu
 #SBATCH -p orion
 #SBATCH -q batch
 #SBATCH --ntasks=40
 #SBATCH --cpus-per-task=1
 #SBATCH --time=00:30:00
-#SBATCH -e ${work_dir}/regridding_merge_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}/regridding_merge_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}.err
-#SBATCH -o ${work_dir}/regridding_merge_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}/regridding_merge_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}.out
+#SBATCH -e ${work_dir}/regrid_merge_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}/regrid_merge_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}.err
+#SBATCH -o ${work_dir}/regrid_merge_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}/regrid_merge_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}.out
 
 source ${env_script}
 module load nco
 
-cd ${work_dir}/regridding_merge_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}
+cd ${work_dir}/regrid_merge_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}
 
 # Number of local files
 nlocal=216
@@ -436,7 +436,7 @@ for itot in \$(seq 1 \${nlocal}); do
    filename_full_2D=${data_dir_c192}/${bump_dir}/nicas_${yyyymmddhh_first}-${yyyymmddhh_last}/nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_2D_nicas_local_\${ntotpad}-\${itotpad}.nc
    rm -f \${filename_full_3D}
    rm -f \${filename_full_2D}
-   echo "#!/bin/bash" > regridding_merge_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_\${itotpad}.sh
+   echo "#!/bin/bash" > regrid_merge_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_\${itotpad}.sh
    for var in ${vars}; do
       if test "\${var}" = "ps"; then
          filename_full=\${filename_full_2D}
@@ -444,7 +444,7 @@ for itot in \$(seq 1 \${nlocal}); do
          filename_full=\${filename_full_3D}
       fi
       filename_var=${data_dir_c192}/${bump_dir}/nicas_${yyyymmddhh_first}-${yyyymmddhh_last}/nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_\${var}_nicas_local_\${ntotpad}-\${itotpad}.nc
-      echo -e "ncks -A \${filename_var} \${filename_full}" >> regridding_merge_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_\${itotpad}.sh
+      echo -e "ncks -A \${filename_var} \${filename_full}" >> regrid_merge_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_\${itotpad}.sh
    done
 done
 
@@ -455,7 +455,7 @@ filename_full_3D=${data_dir_c192}/${bump_dir}/nicas_${yyyymmddhh_first}-${yyyymm
 filename_full_2D=${data_dir_c192}/${bump_dir}/nicas_${yyyymmddhh_first}-${yyyymmddhh_last}/nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_2D_nicas.nc
 rm -f \${filename_full_3D}
 rm -f \${filename_full_2D}
-echo "#!/bin/bash" > regridding_merge_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_\${itotpad}.sh
+echo "#!/bin/bash" > regrid_merge_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_\${itotpad}.sh
 for var in ${vars}; do
    if test "\${var}" = "ps"; then
       filename_full=\${filename_full_2D}
@@ -463,7 +463,7 @@ for var in ${vars}; do
       filename_full=\${filename_full_3D}
    fi
    filename_var=${data_dir_c192}/${bump_dir}/nicas_${yyyymmddhh_first}-${yyyymmddhh_last}/nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_\${var}_nicas.nc
-   echo -e "ncks -A \${filename_var} \${filename_full}" >> regridding_merge_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_\${itotpad}.sh
+   echo -e "ncks -A \${filename_var} \${filename_full}" >> regrid_merge_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_\${itotpad}.sh
 done
 
 # Run scripts in parallel
@@ -474,9 +474,9 @@ for ibatch in \$(seq 1 \${nbatch}); do
       itot=\$((itot+1))
       if test "\${itot}" -le "\${nlocalp1}"; then
          itotpad=\$(printf "%.6d" "\${itot}")
-         echo "Batch \${ibatch} - job \${i}: ./regridding_merge_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_\${itotpad}.sh"
-         chmod 755 regridding_merge_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_\${itotpad}.sh
-         ./regridding_merge_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_\${itotpad}.sh &
+         echo "Batch \${ibatch} - job \${i}: ./regrid_merge_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_\${itotpad}.sh"
+         chmod 755 regrid_merge_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_\${itotpad}.sh
+         ./regrid_merge_nicas_${yyyymmddhh_first}-${yyyymmddhh_last}_\${itotpad}.sh &
       fi
    done
    wait

--- a/src/Workflows/StaticB/bump_1.0/regridding.sh
+++ b/src/Workflows/StaticB/bump_1.0/regridding.sh
@@ -35,7 +35,7 @@ output geometry:
 states:
 - input:
     filetype: gfs
-    datapath: ${data_dir_c384}/${bkg_obs_dir}
+    datapath: ${data_dir_c384}/${bkg_dir}
     filename_cplr: coupler.res
     filename_core: fv_core.res.nc
     filename_trcr: fv_tracer.res.nc
@@ -43,7 +43,7 @@ states:
     psinfile: true
   output:
     filetype: gfs
-    datapath: ${data_dir_c192}/${bkg_obs_dir}
+    datapath: ${data_dir_c192}/${bkg_dir}
     filename_cplr: coupler.res
     filename_core: fv_core.res.nc
     filename_trcr: fv_tracer.res.nc
@@ -70,10 +70,10 @@ mpirun -n 216 ${bin_dir}/fv3jedi_convertstate.x ${yaml_dir}/${yaml_name}
 
 for i in \$(seq 1 6); do
    # Rename background files
-   mv ${data_dir_c192}/${bkg_obs_dir}/${yyyy_obs}${mm_obs}${dd_obs}.${hh_obs}0000.fv_core.res.tile\${i}.nc ${data_dir_c192}/${bkg_obs_dir}/fv_core.res.tile\${i}.nc
-   mv ${data_dir_c192}/${bkg_obs_dir}/${yyyy_obs}${mm_obs}${dd_obs}.${hh_obs}0000.fv_tracer.res.tile\${i}.nc ${data_dir_c192}/${bkg_obs_dir}/fv_tracer.res.tile\${i}.nc
+   mv ${data_dir_c192}/${bkg_dir}/${yyyy_bkg}${mm_bkg}${dd_bkg}.${hh_bkg}0000.fv_core.res.tile\${i}.nc ${data_dir_c192}/${bkg_dir}/fv_core.res.tile\${i}.nc
+   mv ${data_dir_c192}/${bkg_dir}/${yyyy_bkg}${mm_bkg}${dd_bkg}.${hh_bkg}0000.fv_tracer.res.tile\${i}.nc ${data_dir_c192}/${bkg_dir}/fv_tracer.res.tile\${i}.nc
 done
-mv ${data_dir_c192}/${bkg_obs_dir}/${yyyy_obs}${mm_obs}${dd_obs}.${hh_obs}0000.coupler.res ${data_dir_c192}/${bkg_obs_dir}/coupler.res
+mv ${data_dir_c192}/${bkg_dir}/${yyyy_bkg}${mm_bkg}${dd_bkg}.${hh_bkg}0000.coupler.res ${data_dir_c192}/${bkg_dir}/coupler.res
 
 exit 0
 EOF

--- a/src/Workflows/StaticB/bump_1.0/variational.sh
+++ b/src/Workflows/StaticB/bump_1.0/variational.sh
@@ -33,7 +33,7 @@ cost function:
 
   background:
     filetype: gfs
-    datapath: ${data_dir_c384}/${bkg_obs_dir}
+    datapath: ${data_dir_c384}/${bkg_dir}
     filename_cplr: coupler.res
     filename_core: fv_core.res.nc
     filename_sfcw: fv_srf_wnd.res.nc
@@ -111,10 +111,6 @@ cost function:
         verbosity: main
         universe_rad: 2000.0e3
         load_wind_local: 1
-        wind_streamfunction: stream_function
-        wind_velocity_potential: velocity_potential
-        wind_zonal: eastward_wind
-        wind_meridional: northward_wind
 
   observations:
   - obs space:


### PR DESCRIPTION
## Description

This PR is a minor update to make the scripts suite easier to use. A specific README is added [here](https://github.com/JCSDA-internal/fv3-jedi-tools/tree/feature/benchmark/src/Workflows/StaticB) provide some documentation.

**Last thing to do**: move the background and observations on S3. I was able to upload them in the saber directory, but I don't have the permission to move them into the correct directory:
- `s3://jedi-test-files/saber/bkg_2020121500.tar` should be moved to `s3://fv3-jedi/StaticBTraining/C384/Background/`
- `s3://jedi-test-files/saber/obs.tar` should be moved to `s3://fv3-jedi/StaticBTraining/Observations/`

@mmiesch, @danholdaway, could you do that?

All data for the static B training are stored on S3 in `glacier` mode. Should we "defrost" them for Oak Ridge people?

### Issue(s) addressed

None

## Acceptance Criteria (Definition of Done)

Scripts suite working completely on Orion.

## Dependencies

None.

## Impact

None.