### PR TITLE
Raster plot for FV3

### DIFF
--- a/src/raster/fv3grid/README.md
+++ b/src/raster/fv3grid/README.md
@@ -1,0 +1,13 @@
+## How to generate fv3grid files for other resolutions?
+
+- Compile [fv3-bundle](https://github.com/JCSDA/fv3-bundle)
+- Update **npx** and **npy** in the **geometry_gfs** test:
+
+    cd /path/to/your/build/fv3-bundle/fv3-jedi
+    vi test/testinput/geometry_gfs.yaml
+
+- Run the **geometry_gfs** test:
+
+    ctest -R fv3jedi_test_tier1_geometry_gfs
+
+- fv3grid files are located in the **test** directory

--- a/src/raster/fv3grid/fv3grid_c0006.nc4
+++ b/src/raster/fv3grid/fv3grid_c0006.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78334e6054aac707d9a7d36fd827e3a988275ed6c675e604e705ed8dab959e05
+size 22512

--- a/src/raster/fv3grid/fv3grid_c0012.nc4
+++ b/src/raster/fv3grid/fv3grid_c0012.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac31a9912784f16ce8cd62c87712e357170c3cc7221a751a1ad2205be816d74c
+size 46128

--- a/src/raster/fv3grid/fv3grid_c0024.nc4
+++ b/src/raster/fv3grid/fv3grid_c0024.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6602098dc4ff40a5482b717d20fa64d204a41ed4b03ee47121e7416fb19753d
+size 131376

--- a/src/raster/fv3grid/fv3grid_c0048.nc4
+++ b/src/raster/fv3grid/fv3grid_c0048.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9f0b9c8695c6c19e50b33d6ea44520dc7eba5653e25d9b0758df77bf2bd9134
+size 467760

--- a/src/raster/fv3grid/fv3grid_c0096.nc4
+++ b/src/raster/fv3grid/fv3grid_c0096.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db0532c56b7fb2df40b8caa01e30e9ea368aecd016a911c01f815f791f1fcb8e
+size 1804080

--- a/src/raster/fv3grid/fv3grid_c0192.nc4
+++ b/src/raster/fv3grid/fv3grid_c0192.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7cb0afdd8db50a0a83b67e5b0dc471b2d1537b2cea45d5d43a84aa83be2f2291
+size 7132881

--- a/src/raster/fv3grid/fv3grid_c0384.nc4
+++ b/src/raster/fv3grid/fv3grid_c0384.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff2e66123d8498d47b971e610638a35d955d04177d4412f3b9cb5ad41a331d95
+size 28406481

--- a/src/raster/raster.py
+++ b/src/raster/raster.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+
+import os
+import argparse
+import sys
+from netCDF4 import Dataset
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpatches
+import matplotlib.cm as cm
+import numpy as np
+import cartopy.crs as ccrs
+
+# -----------------------------------------------------------------------------
+
+# Environment variables
+
+# FV3_GRID_DIR: directory with FV3 grid files for each resolution ("fv3grid_cNNNN.nc")
+gridfiledir = os.environ.get("FV3_GRID_DIR", os.path.dirname(os.path.realpath(__file__)) + "/fv3grid")
+
+# Hard-coded parameters
+
+# Number of tiles
+ntile = 6
+
+# Projection
+projection = ccrs.Robinson()
+
+# -----------------------------------------------------------------------------
+
+# Parser
+parser = argparse.ArgumentParser()
+
+# GEOS / GFS flag
+parser.add_argument("--geos", dest="geos", action="store_true", help="GEOS input file")
+parser.add_argument("--gfs", dest="gfs", action="store_true", help="GFS input file")
+
+# File path
+parser.add_argument("--filepath", "-f", help="File path")
+
+# Base file path (to compute a difference)
+parser.add_argument("--basefilepath", "-bf", help="Base file path", default=None)
+
+# Variable
+parser.add_argument("--variable", "-v", help="Variable")
+
+# Level
+parser.add_argument("--level", "-l", type=int, help="Level")
+
+# Averaging size (optional, default=1)
+parser.add_argument("--average", "-a", type=int, nargs="?", help="Averaging size", default=1)
+
+# Averaging size (optional, default=0.0)
+parser.add_argument("--threshold", "-th", type=float, nargs="?", help="Value threshold", default=0.0)
+
+# Color map
+parser.add_argument("--colormap", "-cm", nargs="?", help="Colormap", default="jet")
+
+# Output file path
+parser.add_argument("--output", "-o", help="Output file path")
+
+# -----------------------------------------------------------------------------
+
+# Parse arguments
+args = parser.parse_args()
+
+# Print arguments
+print("Parameters:")
+print(" - gridfiledir: " + gridfiledir)
+for arg in vars(args):
+    if not arg is None:
+        print(" - " + arg + ": " + str(getattr(args, arg)))
+
+
+# Check arguments
+if (not (args.geos or args.gfs)):
+    print("ERROR: --geos or --gfs required")
+    sys.exit(1)
+
+# -----------------------------------------------------------------------------
+
+# Lon/lat test
+lon_test = False
+lat_test = False
+
+if lon_test and lat_test:
+    print("ERROR: lon_test and lat_test are mutually exclusive")
+    sys.exit(1)
+
+if (lon_test or lat_test) and args.gfs:
+    print("ERROR: lon_test and lat_test are only available with GFS")
+    sys.exit(1)
+
+# -----------------------------------------------------------------------------
+
+if args.geos:
+    # Check file extension
+    if not args.filepath.endswith(".nc4"):
+        print("   Error: filepath extension should be .nc4")
+        sys.exit(1)
+
+    # Open data file
+    fdata = Dataset(args.filepath, "r", format="NETCDF4")
+
+    if lon_test:
+        # Read lon
+        fld = fdata["lons"][:,:,:]
+    elif lat_test:
+        # Read lat
+        fld = fdata["lats"][:,:,:]
+    else:
+        # Read field
+        fld = fdata[args.variable][0,args.level-1,:,:,:]
+
+    if not args.basefilepath is None:
+        # Check base file extension
+        if not args.basefilepath.endswith(".nc4"):
+            print("   Error: basefilepath extension should be .nc4")
+            sys.exit(1)
+
+        # Open data file
+        fdata = Dataset(args.basefilepath, "r", format="NETCDF4")
+
+        # Read field
+        basefld = fdata[args.variable][0,args.level-1,:,:,:]
+
+        # Compute increment
+        fld = fld - basefld
+
+    # Get shape
+    shp = np.shape(fld)
+    ny = shp[1]
+    nx = shp[2]
+else:
+    # Check file extension
+    if not args.filepath.endswith(".nc"):
+        print("   Error: filepath extension should be .nc")
+        sys.exit(1)
+
+    for itile in range(0, ntile):
+        # Open data file
+        filename = args.filepath.replace(".nc", ".tile" + str(itile+1) + ".nc")
+        fdata = Dataset(filename, "r", format="NETCDF4")
+
+        # Read field
+        fld_tmp = fdata[args.variable][0,args.level-1,:,:]
+
+        if itile == 0:
+            # Get shape
+            shp = np.shape(fld_tmp)
+            ny = shp[0]
+            nx = shp[1]
+
+            # Initialize field
+            fld = np.zeros((ntile, ny, nx))
+
+        # Copy field
+        fld[itile,:,:] = fld_tmp
+
+    if not args.basefilepath is None:
+        # Check base file extension
+        if not args.basefilepath.endswith(".nc"):
+            print("   Error: basefilepath extension should be .nc")
+            sys.exit(1)
+
+        for itile in range(0, ntile):
+            # Open data file
+            filename = args.basefilepath.replace(".nc", ".tile" + str(itile+1) + ".nc")
+            fdata = Dataset(filename, "r", format="NETCDF4")
+
+            # Read field
+            fld_tmp = fdata[args.variable][0,args.level-1,:,:]
+
+            # Copy field
+            fld[itile,:,:] = fld[itile,:,:] - fld_tmp
+
+# Open grid file
+fgrid = Dataset(gridfiledir + "/fv3grid_c" + str(nx).zfill(4) + ".nc4", "r", format="NETCDF4")
+
+# Read grid vertices lons/lats
+vlons = np.degrees(fgrid["vlons"][:,:,:])
+vlats = np.degrees(fgrid["vlats"][:,:,:])
+if lon_test:
+    # Check lon
+    flons = np.degrees(fgrid["flons"][:,:,:])
+    print(np.max(np.abs(fld-flons)))
+elif lat_test:
+    # Read lat
+    flats = np.degrees(fgrid["flats"][:,:,:])
+    print(np.max(np.abs(fld-flats)))
+
+# Compute min/max
+vmin = np.min(fld)
+vmax = np.max(fld)
+norm = plt.Normalize(vmin=vmin, vmax=vmax)
+
+# Compute averaging norm
+normavg = 1.0/args.average**2
+
+# Initialize figure
+fig,ax = plt.subplots(figsize=(8,8),subplot_kw=dict(projection=projection))
+ax.set_global()
+ax.coastlines()
+ax.gridlines()
+
+# Colormap
+cmap = cm.get_cmap(args.colormap)
+
+# Figure title
+if args.average > 1:
+    plt.title(args.variable + " at level " + str(args.level) + " - C" + str(nx) + " - Avg. " + str(args.average))
+else:
+    plt.title(args.variable + " at level " + str(args.level) + " - C" + str(nx))
+
+# Loop over tiles
+for itile in range(0, ntile):
+    # Loop over polygons
+    for iy in range(0, ny, args.average):
+        for ix in range(0, nx, args.average):
+            # Average value
+            value = 0.0
+            for iya in range(0, args.average):
+                for ixa in range(0, args.average):
+                    value += fld[itile,iy+ixa,ix+ixa]
+            value = value*normavg
+
+            if abs(value) >= args.threshold:
+                # Polygon coordinates      
+                xy = [[vlons[itile,iy+0,ix+0], vlats[itile,iy+0,ix+0]],
+                      [vlons[itile,iy+0,ix+args.average], vlats[itile,iy+0,ix+args.average]],
+                      [vlons[itile,iy+args.average,ix+args.average], vlats[itile,iy+args.average,ix+args.average]],
+                      [vlons[itile,iy+args.average,ix+0], vlats[itile,iy+args.average,ix+0]]]
+
+                # Add polygon
+                ax.add_patch(mpatches.Polygon(xy=xy, closed=True, facecolor=cmap(norm(value)),transform=ccrs.Geodetic()))
+
+# Set colorbar
+sm = cm.ScalarMappable(cmap=args.colormap, norm=plt.Normalize(vmin=vmin, vmax=vmax))
+sm.set_array([])
+plt.colorbar(sm, orientation="horizontal", pad=0.06)
+
+# Save and close figure
+plt.savefig(args.output + ".jpg", format="jpg", dpi=300)
+plt.close()

--- a/src/raster/raster.py
+++ b/src/raster/raster.py
@@ -1,4 +1,13 @@
 #!/usr/bin/env python3
+"""
+@author: Benjamin Menetrier
+@description: plotting facility for FV3
+"""
+
+# (C) Copyright 2021 UCAR
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
 
 import os
 import argparse
@@ -37,8 +46,8 @@ parser.add_argument("--gfs", dest="gfs", action="store_true", help="GFS input fi
 # File path
 parser.add_argument("--filepath", "-f", help="File path")
 
-# Base file path (to compute a difference)
-parser.add_argument("--basefilepath", "-bf", help="Base file path", default=None)
+# Base file path to compute a difference (optional)
+parser.add_argument("--basefilepath", "-bf", help="Base file path")
 
 # Variable
 parser.add_argument("--variable", "-v", help="Variable")
@@ -49,11 +58,11 @@ parser.add_argument("--level", "-l", type=int, help="Level")
 # Averaging size (optional, default=1)
 parser.add_argument("--average", "-a", type=int, nargs="?", help="Averaging size", default=1)
 
-# Averaging size (optional, default=0.0)
+# Threshold (optional, default=0.0)
 parser.add_argument("--threshold", "-th", type=float, nargs="?", help="Value threshold", default=0.0)
 
-# Color map
-parser.add_argument("--colormap", "-cm", nargs="?", help="Colormap", default="jet")
+# Color map (optional, default=jet)
+parser.add_argument("--colormap", "-cm", type=str, nargs="?", help="Colormap")
 
 # Output file path
 parser.add_argument("--output", "-o", help="Output file path")
@@ -62,6 +71,10 @@ parser.add_argument("--output", "-o", help="Output file path")
 
 # Parse arguments
 args = parser.parse_args()
+
+# Set default string values
+if args.colormap is None:
+    args.colormap = "jet"
 
 # Print arguments
 print("Parameters:")


### PR DESCRIPTION
## Description

This PR adds a new script `raster.py` that plots FV3 data on the native cubed-sphere grid, for GFS and GEOS formats. Using `cartopy`, it plots polygons and get the edges coordinates from the geometry files produced by `fv3jedi_test_tier1_geometry_gfs` (also used by `femps`).

Here is an example at C96, with the command line:
```
./raster.py --geos -f /path/to/geos_file_c96.nc4 -v t -l 80 -o test_c96
```

![test_c96](https://user-images.githubusercontent.com/30638301/143494130-8ef2c091-f566-4e41-867d-bbf2742500ca.jpg)

The same figure could be obtained with a GFS file:
```
./raster.py --gfs -f /path/to/gfs_file_c96.fv_core.res.nc -v t -l 80 -o test_c96
```

Main arguments are:
- `--geos` or `--gfs` to specify the input file format
- `-f` to set the file path
- `-bf` to set the base file path and plot the difference file - base file (optional)
- `-v` to set the variable name
- `-l` to set the level
- `-o` to set the output file name

The resolution is guessed from the field size and the appropriate grid data file is picked from the directory `fv3grid` (located in the same directory as the `raster.py` script) or from a directory given by the environment variable `FV3_GRID_DIR`.

For instance, the same field interpolated at C24 gives:

![test_c24](https://user-images.githubusercontent.com/30638301/143494148-be1cdc0c-2f3a-46e8-86b7-26b1aeeccda9.jpg)

Since the script can be slow for large grids, I implemented two other options:
1) Averaging: the `-a` argument averages the values over `a x a` grid cells. For instance, a C96 grid with `-a 4` has a C24 resolution:
```
./raster.py --geos -f /path/to/geos_file_c96.nc4 -v t -l 80 -a 4 -o test_c96_a4
```

![test_c96_a4](https://user-images.githubusercontent.com/30638301/143494476-c4dd2a1f-4b24-4c57-af20-08ade899e863.jpg)

2) A threshold can be set with the `-th` argument, excluding all values whose absolute value is lower than `th`. For instance: 
```
./raster.py --geos -f /path/to/geos_file_c96.nc4 -v t -l 80 -th 250 -o test_c96_th
```

![test_c96_th](https://user-images.githubusercontent.com/30638301/143495619-2893873c-a677-4ab5-82cf-779c30cdc3f3.jpg)

The colormap can be changed with the `-cm` flag:
```
./raster.py --geos -f /path/to/geos_file_c24.nc4 -v t -l 80 -cm Spectral -o test_c24_spectral
```

![test_c24_spectral](https://user-images.githubusercontent.com/30638301/143495985-a024f404-bc12-4939-b6dd-4ae61638fe61.jpg)

The `--centered` flag can be added to use a centered colormap (symmetric around 0). In this case, the default colormap is "coolwarm" instead of "jet":

![increment_sondes_t](https://user-images.githubusercontent.com/30638301/143564445-012f4013-c862-4f4b-9012-542c66c1a540.jpg)

Since this script does not any involve any interpolation or triangulation, it should be pretty robust. The projection is hard-coded but it could be passed as another optional argument. We could also imagine zoom arguments, etc.

### Issue(s) addressed

None.

## Acceptance Criteria (Definition of Done)

`raster.py` script working on HPC.

## Dependencies

None.

## Impact

None.